### PR TITLE
Example layout and certificate layout change

### DIFF
--- a/resources/views/certificate/layout.blade.php
+++ b/resources/views/certificate/layout.blade.php
@@ -54,6 +54,11 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                 break;
         }
     @endphp
+    {{-- Start Layout From Here --}}
+    @php
+        // Options: certificate, editor
+        $layoutFor = 'certificate';
+    @endphp
     <div id="canvas">
         @if(!empty($eventFontImages['backgroundImage']))
             <img src="{{ $eventFontImages['backgroundImage'] }}" alt="Background image" style="position: absolute; width: {{ $backgroundImageWidth }}; height: {{ $backgroundImageHeight }};" />
@@ -292,7 +297,7 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                 $detailsTranslate = '';
             }
         @endphp
-        <div id="details" class="draggable-resizable-square" style="{{ $detailsTranslate }} position: absolute; top: 17%; height: {{ $detailsHeight }}; width: {{ $detailsWidth }}; text-align: center; z-index: 10;">
+        <div id="details" class="draggable-resizable" style="{{ $detailsTranslate }} position: absolute; top: 17%; height: {{ $detailsHeight }}; width: {{ $detailsWidth }}; text-align: center; z-index: 10;">
             <div id="details-type" style="margin-bottom: 0.8mm;">
                 @php
                     if(!empty($certificateData->type)){
@@ -311,7 +316,7 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                                 break;
                         }
                     }else{
-                        $certificateTitle = 'Sijil Penyertaan';
+                        $certificateTitle = 'Sijil Pencapaian';
                     }
                 @endphp
                 <p class="details-text-type">{{ strtoupper($certificateTitle) }}</p>
@@ -334,7 +339,7 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                                 break;
                         }
                     }else{
-                        $certificateIntro = 'Adalah dengan ini diakui bahawa';
+                        $certificateIntro = 'Setinggi-tinggi tahniah diucapkan kepada';
                     }
                 @endphp
                 <p class="details-text-first">{{ $certificateIntro }}</p>
@@ -374,7 +379,7 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                                 break;
                         }
                     }else{
-                        $certificateCredit = 'Telah menyertai';
+                        $certificateCredit = 'Di atas pencapaian';
                     }
                 @endphp
                 @php
@@ -389,6 +394,8 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                     @if($certificateData->type !== 'participation')
                         <p class="details-text-second">{{ strtoupper($certificatePosition) }}</p>
                     @endif
+                @else
+                    <p class="details-text-second">{{ strtoupper($certificatePosition) }}</p>
                 @endif
             </div>
             <div id="details-event-name" style="margin-bottom: 0.8mm;">
@@ -396,6 +403,8 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                     @if($certificateData->type !== 'participation')
                         <p class="details-text-first">Dalam</p>
                     @endif
+                @else
+                    <p class="details-text-first">Dalam</p>
                 @endif
                 <p class="details-text-second">{{ strtoupper($eventData->name) }}</p>
             </div>
@@ -405,10 +414,12 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                     <p class="details-text-second">{{ strtoupper($certificateData->category) }}</p>
                 </div>
             @else
-                <div id="details-category" style="margin-bottom: 0.8mm;">
-                    <p class="details-text-first">Kategori</p>
-                    <p class="details-text-second">{{ strtoupper($defaultText) }}</p>
-                </div>
+                @if($layoutFor == 'editor')
+                    <div id="details-category" style="margin-bottom: 0.8mm;">
+                        <p class="details-text-first">Kategori</p>
+                        <p class="details-text-second">{{ strtoupper($defaultText) }}</p>
+                    </div>
+                @endif
             @endif
             <div id="details-date" style="margin-bottom: 0.8mm;">
                 <p class="details-text-first">Pada</p>

--- a/resources/views/event/layout.blade.php
+++ b/resources/views/event/layout.blade.php
@@ -122,6 +122,11 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                         break;
                 }
             @endphp
+            {{-- Start Layout From Here --}}
+            @php
+                // Options: certificate, editor
+                $layoutFor = 'editor';
+            @endphp
             <div id="canvas" style="width: {{ $backgroundImageWidth }}; height: {{ $backgroundImageHeight }}; position: relative; background: #fff;" class="mt-3 mb-5">
                 @if(!empty($eventFontImages['backgroundImage']))
                     <img src="{{ $eventFontImages['backgroundImage'] }}" alt="Background image" style="position: absolute; width: {{ $backgroundImageWidth }}; height: {{ $backgroundImageHeight }};" />
@@ -379,7 +384,7 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                                         break;
                                 }
                             }else{
-                                $certificateTitle = 'Sijil Penyertaan';
+                                $certificateTitle = 'Sijil Pencapaian';
                             }
                         @endphp
                         <p class="details-text-type">{{ strtoupper($certificateTitle) }}</p>
@@ -402,7 +407,7 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                                         break;
                                 }
                             }else{
-                                $certificateIntro = 'Adalah dengan ini diakui bahawa';
+                                $certificateIntro = 'Setinggi-tinggi tahniah diucapkan kepada';
                             }
                         @endphp
                         <p class="details-text-first">{{ $certificateIntro }}</p>
@@ -442,7 +447,7 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                                         break;
                                 }
                             }else{
-                                $certificateCredit = 'Telah menyertai';
+                                $certificateCredit = 'Di atas pencapaian';
                             }
                         @endphp
                         @php
@@ -457,6 +462,8 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                             @if($certificateData->type !== 'participation')
                                 <p class="details-text-second">{{ strtoupper($certificatePosition) }}</p>
                             @endif
+                        @else
+                            <p class="details-text-second">{{ strtoupper($certificatePosition) }}</p>
                         @endif
                     </div>
                     <div id="details-event-name" style="margin-bottom: 0.8mm;">
@@ -464,6 +471,8 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                             @if($certificateData->type !== 'participation')
                                 <p class="details-text-first">Dalam</p>
                             @endif
+                        @else
+                            <p class="details-text-first">Dalam</p>
                         @endif
                         <p class="details-text-second">{{ strtoupper($eventData->name) }}</p>
                     </div>
@@ -473,10 +482,12 @@ along with SeaJell.  If not, see <https://www.gnu.org/licenses/>. --}}
                             <p class="details-text-second">{{ strtoupper($certificateData->category) }}</p>
                         </div>
                     @else
-                        <div id="details-category" style="margin-bottom: 0.8mm;">
-                            <p class="details-text-first">Kategori</p>
-                            <p class="details-text-second">{{ strtoupper($defaultText) }}</p>
-                        </div>
+                        @if($layoutFor == 'editor')
+                            <div id="details-category" style="margin-bottom: 0.8mm;">
+                                <p class="details-text-first">Kategori</p>
+                                <p class="details-text-second">{{ strtoupper($defaultText) }}</p>
+                            </div>
+                        @endif
                     @endif
                     <div id="details-date" style="margin-bottom: 0.8mm;">
                         <p class="details-text-first">Pada</p>


### PR DESCRIPTION
Example layout in the layout editing page must follow the participation
or appreciation items because it's taller than participation layout.
This is to make certificate layout is more related to how editor layout
looks.

For certificate layout, if there's no category, DON'T show it.
Not even the defaultText AKA testing/example text.

Close #92