### PR TITLE
Fixed get_locale() helper can't query system_settings table

### DIFF
--- a/app/Helper/Helper.php
+++ b/app/Helper/Helper.php
@@ -26,8 +26,12 @@ if (!function_exists('get_locale')) {
         }
 
         // Fallback to user setting if does exist
-        if ($systemSetting = SystemSetting::query()->find(1)) {
-            return $systemSetting->language;
+        if (Schema::hasTable('system_settings')) {
+            if (SystemSetting::where('id', 1)->first()) {
+                $systemSetting = SystemSetting::query()->find(1);
+
+                return $systemSetting->language;
+            }
         }
 
         // Fallback to default application locale


### PR DESCRIPTION
When fresh installing the system, tables haven't been migrated yet.
So it the helper would throw an error not finding system_settings table.
Here's a fix for it.